### PR TITLE
Refactor object links to relation entities with bidirectional traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,17 @@ Byggdelssystemet är ett BIM-liknande informationshanteringssystem som ger anvä
 UNIQUE(object_id, field_id)
 ```
 
-### ObjectRelations (Kopplingar)
+### ObjectRelations (Relationsobjekt)
 ```sql
 - id: SERIAL PRIMARY KEY
-- source_object_id: FK → Objects
-- target_object_id: FK → Objects
+- source_object_id: FK → Objects   # objectA_id
+- target_object_id: FK → Objects   # objectB_id
 - relation_type: VARCHAR(100)
 - description: TEXT
 - relation_metadata: JSONB
+
+# API aliaser:
+# objectA_id, objectA_type, objectB_id, objectB_type
 INDEX: source_object_id, target_object_id, relation_type
 ```
 
@@ -178,12 +181,19 @@ PUT    /api/objects/{id}              # Uppdatera objekt
 DELETE /api/objects/{id}              # Ta bort objekt
 ```
 
-### Relations
+### Relations (relationsobjekt)
 ```bash
-GET    /api/objects/{id}/relations    # Hämta relationer
-POST   /api/objects/{id}/relations    # Skapa relation
-PUT    /api/relations/{id}            # Uppdatera relation
-DELETE /api/relations/{id}            # Ta bort relation
+# Objektspecifika relationer (inkommande + utgående)
+GET    /api/objects/{id}/relations
+POST   /api/objects/{id}/relations
+PUT    /api/objects/{id}/relations/{relation_id}
+DELETE /api/objects/{id}/relations/{relation_id}
+
+# Generell relation-API
+GET    /api/relations                 # Lista alla relationer
+GET    /api/relations?object_id={id}  # Filtrera relationer för objekt
+POST   /api/relations                 # Skapa relation med objectA_id/objectB_id
+DELETE /api/relations/{relation_id}
 ```
 
 ### Documents
@@ -193,6 +203,9 @@ POST   /api/objects/{id}/documents    # Ladda upp (multipart/form-data)
 GET    /api/documents/{id}/download   # Ladda ner
 DELETE /api/documents/{id}            # Ta bort
 ```
+
+
+Relationer traverseras nu från båda håll i både API och frontend (objektpanel + trädvy), vilket ersätter behovet av direkta barn/förälder-kopplingar i objekten.
 
 ### Search & Stats
 ```bash

--- a/app.py
+++ b/app.py
@@ -53,6 +53,13 @@ def create_app():
             run_metadata_migration(db)
         except Exception as e:
             logger.warning(f"Metadata fields migration may have already run: {str(e)}")
+
+        try:
+            from migrations.migrate_direct_links_to_relations import run_migration as run_relation_migration
+            migrated_count = run_relation_migration(db)
+            logger.info(f"Direct-link migration created {migrated_count} relation entities")
+        except Exception as e:
+            logger.warning(f"Direct-link migration may have already run or has no data: {str(e)}")
         
         seed_data(app)
     

--- a/migrations/migrate_direct_links_to_relations.py
+++ b/migrations/migrate_direct_links_to_relations.py
@@ -1,0 +1,83 @@
+"""Migrate legacy direct object links (children/parentId) into relation entities."""
+
+from models import db, ObjectField, ObjectData, ObjectRelation
+
+
+def _parse_id_list(raw_value):
+    if raw_value is None:
+        return []
+    text = str(raw_value).strip()
+    if not text:
+        return []
+
+    # Accept comma-separated and JSON-like array payloads
+    cleaned = text.replace('[', '').replace(']', '').replace('"', '').replace("'", '')
+    values = []
+    for token in cleaned.split(','):
+        token = token.strip()
+        if token.isdigit():
+            values.append(int(token))
+    return values
+
+
+def run_migration(db_instance=db):
+    session = db_instance.session
+
+    parent_fields = ObjectField.query.filter(ObjectField.field_name.in_(['parentId', 'parent_id'])).all()
+    children_fields = ObjectField.query.filter(ObjectField.field_name.in_(['children', 'childIds', 'child_ids'])).all()
+
+    created = 0
+
+    # parentId -> relation(parent -> child)
+    for field in parent_fields:
+        entries = ObjectData.query.filter_by(field_id=field.id).all()
+        for entry in entries:
+            parent_candidates = _parse_id_list(entry.value_text)
+            if not parent_candidates:
+                continue
+
+            parent_id = parent_candidates[0]
+            child_id = entry.object_id
+
+            exists = ObjectRelation.query.filter_by(
+                source_object_id=parent_id,
+                target_object_id=child_id,
+                relation_type='ingår_i'
+            ).first()
+            if exists:
+                continue
+
+            session.add(ObjectRelation(
+                source_object_id=parent_id,
+                target_object_id=child_id,
+                relation_type='ingår_i',
+                relation_metadata={'migrated_from': field.field_name}
+            ))
+            created += 1
+
+    # children -> relation(parent -> child)
+    for field in children_fields:
+        entries = ObjectData.query.filter_by(field_id=field.id).all()
+        for entry in entries:
+            parent_id = entry.object_id
+            child_ids = _parse_id_list(entry.value_text)
+
+            for child_id in child_ids:
+                exists = ObjectRelation.query.filter_by(
+                    source_object_id=parent_id,
+                    target_object_id=child_id,
+                    relation_type='ingår_i'
+                ).first()
+                if exists:
+                    continue
+
+                session.add(ObjectRelation(
+                    source_object_id=parent_id,
+                    target_object_id=child_id,
+                    relation_type='ingår_i',
+                    relation_metadata={'migrated_from': field.field_name}
+                ))
+                created += 1
+
+    session.commit()
+    return created

--- a/models/relation.py
+++ b/models/relation.py
@@ -30,6 +30,11 @@ class ObjectRelation(db.Model):
             'id': self.id,
             'source_object_id': self.source_object_id,
             'target_object_id': self.target_object_id,
+            # Standardized relation entity aliases
+            'objectA_id': self.source_object_id,
+            'objectA_type': self.source_object.object_type.name if self.source_object and self.source_object.object_type else None,
+            'objectB_id': self.target_object_id,
+            'objectB_type': self.target_object.object_type.name if self.target_object and self.target_object.object_type else None,
             'relation_type': self.relation_type,
             'description': self.description,
             'metadata': self.relation_metadata,  # Return as 'metadata' in API

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -8,6 +8,7 @@ from routes.documents import bp as documents_bp
 from routes.search import bp as search_bp
 from routes.stats import stats_bp
 from routes.view_config import bp as view_config_bp
+from routes.relation_entities import bp as relation_entities_bp
 
 def register_blueprints(app):
     """Register all blueprints with the Flask app"""
@@ -18,3 +19,4 @@ def register_blueprints(app):
     app.register_blueprint(search_bp)
     app.register_blueprint(stats_bp, url_prefix='/api')
     app.register_blueprint(view_config_bp)
+    app.register_blueprint(relation_entities_bp)

--- a/routes/relation_entities.py
+++ b/routes/relation_entities.py
@@ -1,0 +1,71 @@
+from flask import Blueprint, jsonify, request
+from models import db, Object, ObjectRelation
+
+bp = Blueprint('relation_entities', __name__, url_prefix='/api/relations')
+
+
+@bp.route('', methods=['GET'])
+def list_relations():
+    """List all relation entities, optional filter by object_id."""
+    object_id = request.args.get('object_id', type=int)
+
+    query = ObjectRelation.query
+    if object_id is not None:
+        query = query.filter(
+            (ObjectRelation.source_object_id == object_id) |
+            (ObjectRelation.target_object_id == object_id)
+        )
+
+    relations = query.order_by(ObjectRelation.created_at.desc()).all()
+
+    payload = []
+    for rel in relations:
+        item = rel.to_dict(include_objects=True)
+        if object_id is not None:
+            item['direction'] = 'outgoing' if rel.source_object_id == object_id else 'incoming'
+        payload.append(item)
+
+    return jsonify(payload), 200
+
+
+@bp.route('', methods=['POST'])
+def create_relation():
+    """Create relation entity between two objects."""
+    data = request.get_json() or {}
+
+    source_object_id = data.get('source_object_id') or data.get('objectA_id')
+    target_object_id = data.get('target_object_id') or data.get('objectB_id')
+    relation_type = data.get('relation_type')
+
+    if not source_object_id or not target_object_id or not relation_type:
+        return jsonify({'error': 'source_object_id/objectA_id, target_object_id/objectB_id and relation_type are required'}), 400
+
+    if source_object_id == target_object_id:
+        return jsonify({'error': 'Self-relations are not allowed'}), 400
+
+    source_object = Object.query.get(source_object_id)
+    target_object = Object.query.get(target_object_id)
+
+    if not source_object or not target_object:
+        return jsonify({'error': 'Invalid object IDs'}), 400
+
+    relation = ObjectRelation(
+        source_object_id=source_object_id,
+        target_object_id=target_object_id,
+        relation_type=relation_type,
+        description=data.get('description'),
+        relation_metadata=data.get('metadata', {})
+    )
+
+    db.session.add(relation)
+    db.session.commit()
+
+    return jsonify(relation.to_dict(include_objects=True)), 201
+
+
+@bp.route('/<int:relation_id>', methods=['DELETE'])
+def delete_relation(relation_id):
+    relation = ObjectRelation.query.get_or_404(relation_id)
+    db.session.delete(relation)
+    db.session.commit()
+    return jsonify({'message': 'Relation deleted successfully'}), 200

--- a/static/js/components/tree-view.js
+++ b/static/js/components/tree-view.js
@@ -44,7 +44,7 @@ class TreeView {
                         <tr>
                             <th data-sortable data-sort-type="text" style="width: 50%;">Namn</th>
                             <th data-sortable data-sort-type="text" style="width: 20%;">ID</th>
-                            <th data-sortable data-sort-type="text" style="width: 30%;">Typ</th>
+                            <th data-sortable data-sort-type="text" style="width: 30%;">Typ / Relation</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -109,7 +109,7 @@ class TreeView {
                     <td>
                         ${node.auto_id ? `<a href="javascript:void(0)" class="tree-id-link" data-node-id="${node.id}" data-node-type="${node.type}">${node.auto_id}</a>` : ''}
                     </td>
-                    <td>${node.type || ''}</td>
+                    <td>${node.type || ''}${node.relation ? `<br><small>${node.relation.relation_type} (${node.direction === 'incoming' ? 'inkommande' : 'utgående'})</small>` : ''}</td>
                 </tr>
             `;
         }


### PR DESCRIPTION
### Motivation
- Replace fragile direct object links (fields like `children`/`parentId`) with first-class relation entities so relationships are traversable from both objects. 
- Provide a standardized relation entity payload and a generic API to create/read/delete relations independent of object payloads.

### Description
- Added `objectA_id/objectA_type` and `objectB_id/objectB_type` aliases to `ObjectRelation.to_dict()` alongside existing `source/target` fields for a stable relation-entity contract (`models/relation.py`).
- Updated object-scoped relations API to return both incoming and outgoing relations with explicit `direction` metadata and to allow deletion when the object is on either side (`routes/object_relations.py`).
- Introduced a new generic relation-entity API under `GET/POST/DELETE /api/relations` (`routes/relation_entities.py`) and registered its blueprint (`routes/__init__.py`).
- Reworked the tree assembly (`/api/objects/tree`) to build nodes from relation entities in both directions and to include relation metadata per linked node (`routes/objects.py`).
- Refactored the frontend relation UI (`static/js/components/relation-manager.js`) and tree rendering (`static/js/components/tree-view.js`) to consume relation-entity payloads, show direction (incoming/outgoing), and handle deletes via relation entities.
- Added a migration script to convert legacy `children`/`parentId`-style fields into relation entities (`migrations/migrate_direct_links_to_relations.py`) and wired it into app startup (`app.py`).
- Updated documentation to describe the new relation model and API aliases (`README.md`).

### Testing
- Ran bytecode compilation of relevant modules with `python -m compileall app.py routes models migrations static/js/components`, which succeeded. 
- Attempted an app startup smoke test with `from app import create_app`, which failed due to missing local PostgreSQL connection in the environment (OperationalError). 
- Attempted to run with SQLite via `DATABASE_URL=sqlite:////tmp/byggdemo.db python app.py`, which failed because PostgreSQL `JSONB` types are not supported by the SQLite dialect in this setup (compile error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b49229fb88320870651db4a0cf4b0)