### PR TITLE
Fix relation modal table search/filter/sort parity and button UI

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -636,10 +636,17 @@ body {
 }
 
 .relation-add-btn {
-    font-size: 1rem;
-    font-weight: 700;
-    min-width: 36px;
-    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 3px 8px;
+    min-width: auto;
+    height: 26px;
+    line-height: 1;
+    white-space: nowrap;
 }
 
 .relation-pagination {

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,6 +119,7 @@
                         <table class="data-table" id="relation-object-table">
                             <thead>
                                 <tr id="relation-table-headers"></tr>
+                                <tr id="relation-table-search-row" class="column-search-row"></tr>
                             </thead>
                             <tbody id="relation-object-table-body"></tbody>
                         </table>


### PR DESCRIPTION
### Motivation
- Bring the relation-modal table behaviour in line with the object-list by fixing global search, type filtering, per-column search, sorting and pagination so users have a consistent experience when selecting relation candidates.
- Improve maintainability by centralising the relation-table data flow into a single client-side pipeline that can be reused and extended.
- Harmonize UI details so the `Lägg till` action button matches the rest of the application in size and visual language.

### Description
- Implemented a client-side pipeline for the relation modal including `filteredItems`, `columnSearches`, `sortField` and `sortDirection`, plus `applyRelationTableFilters()` to perform global search, per-column filters, sorting and pagination in one flow (updated `static/js/components/relation-manager.js`).
- Made the table headers clickable and sortable with visual indicators (`↕`, `↑`, `↓`) and attached header click handlers to toggle sort direction (updated `static/js/components/relation-manager.js`).
- Added a column-search row to the modal markup (`<tr id="relation-table-search-row">`) and wired column search inputs to live filtering (updated `templates/index.html` and `static/js/components/relation-manager.js`).
- Adjusted `loadRelationCandidates()` to handle both array and paginated responses from `ObjectsAPI.getAllPaginated()` and to separate server fetch from client-side filtering (updated `static/js/components/relation-manager.js`).
- Updated the `relation-add-btn` styling and button text to a smaller, inline layout and moved the plus sign to the right so it reads e.g. `Lägg till +` and looks consistent with other buttons (updated `static/css/style.css` and `static/js/components/relation-manager.js`).

### Testing
- Ran `pytest -q` which reported "no tests ran" because the repository contains no automated test suite for these changes. 
- Ran `python -m compileall app.py routes models static/js/components/relation-manager.js` which completed successfully to validate Python files compiled. 
- Attempted to start the app with `python app.py` but local startup failed due to an unavailable PostgreSQL instance on `localhost:5432`, so visual/manual validation in a browser could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba1a485fc8320bf10e09a108966bf)