### PR TITLE
Refine relation modal basket UX and stabilize modal layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -14,7 +14,7 @@
     --status-obsolete: #ef4444;
     
     --bg-primary: #ffffff;
-    --bg-secondary: #f8fafc;
+    --bg-secondary: #f1f5f9;
     --bg-tertiary: #f1f5f9;
     --border-color: #e2e8f0;
     --text-primary: #1e293b;
@@ -582,13 +582,16 @@ body {
 .relation-modal {
     width: 90vw;
     max-width: 1400px;
-    max-height: 90vh;
+    height: min(92vh, 900px);
+    max-height: 92vh;
+    overflow: hidden;
 }
 
 .relation-modal-content {
     display: flex;
     flex-direction: column;
-    min-height: 80vh;
+    height: 100%;
+    min-height: 0;
 }
 
 .modal-subtitle {
@@ -620,6 +623,11 @@ body {
     min-height: 0;
 }
 
+.relation-basket-section {
+    display: flex;
+    flex-direction: column;
+}
+
 .relation-filters {
     display: flex;
     gap: var(--spacing-sm);
@@ -639,14 +647,20 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 4px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 3px 8px;
-    min-width: auto;
-    height: 26px;
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 0;
+    width: 24px;
+    height: 24px;
     line-height: 1;
-    white-space: nowrap;
+    border-radius: 999px;
+}
+
+.relation-add-btn.is-added {
+    background: #dcfce7;
+    border-color: #86efac;
+    color: #15803d;
+    cursor: default;
 }
 
 .relation-pagination {
@@ -664,21 +678,66 @@ body {
     margin-bottom: var(--spacing-sm);
 }
 
+.basket-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+}
+
 .relation-basket-list {
-    max-height: 28vh;
+    flex: 1;
+    min-height: 280px;
+    max-height: none;
     overflow: auto;
     border: 1px solid var(--border-color);
     border-radius: var(--radius-sm);
     background: var(--bg-primary);
-    margin-bottom: var(--spacing-md);
+    margin-bottom: var(--spacing-sm);
 }
 
 .basket-item {
     display: flex;
     justify-content: space-between;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-sm);
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: 6px var(--spacing-sm);
     border-bottom: 1px solid var(--border-color);
+}
+
+.basket-item-main {
+    min-width: 0;
+}
+
+.basket-item-title {
+    display: block;
+    font-size: 0.8125rem;
+    line-height: 1.2;
+    margin-bottom: 2px;
+}
+
+.basket-item-meta {
+    display: block;
+    font-size: 0.6875rem;
+    color: var(--text-secondary);
+}
+
+.basket-remove-btn {
+    border: none;
+    background: transparent;
+    color: var(--danger-color);
+    font-size: 1rem;
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.basket-remove-btn:hover {
+    background: rgba(239, 68, 68, 0.12);
 }
 
 .basket-item:last-child {
@@ -688,6 +747,7 @@ body {
 .relation-settings-form {
     border-top: 1px solid var(--border-color);
     padding-top: var(--spacing-sm);
+    flex-shrink: 0;
 }
 
 .relation-result-success {
@@ -1969,6 +2029,7 @@ body {
 @media (max-width: 768px) {
     .relation-modal {
         width: 96vw;
+        height: 94vh;
     }
 
     .relation-modal-layout {

--- a/static/js/components/relation-manager.js
+++ b/static/js/components/relation-manager.js
@@ -332,7 +332,15 @@ function renderRelationTable() {
                 <td>${escapeHtml(getObjectDisplayName(item))}</td>
                 <td>${escapeHtml(item.object_type?.name || '-')}</td>
                 <td>${escapeHtml(String(dynamicValue))}</td>
-                <td><button type="button" class="btn btn-primary btn-sm relation-add-btn" data-id="${item.id}" aria-label="Lägg till ${escapeHtml(getObjectDisplayName(item))}">${inBasket ? 'Tillagd ✓' : 'Lägg till +'}</button></td>
+                <td>
+                    <button
+                        type="button"
+                        class="btn btn-primary btn-sm relation-add-btn ${inBasket ? 'is-added' : ''}"
+                        data-id="${item.id}"
+                        aria-label="${inBasket ? `Redan tillagd: ${escapeHtml(getObjectDisplayName(item))}` : `Lägg till ${escapeHtml(getObjectDisplayName(item))}`}"
+                        ${inBasket ? 'disabled' : ''}
+                    >${inBasket ? '✓' : '+'}</button>
+                </td>
             </tr>
         `;
     }).join('');
@@ -420,15 +428,15 @@ function renderBasket() {
 
     list.innerHTML = relationModalState.basket.map(item => `
         <div class="basket-item">
-            <div>
-                <strong>${escapeHtml(getObjectDisplayName(item))}</strong>
-                <div><small>${escapeHtml(item.object_type?.name || '-')}</small></div>
+            <div class="basket-item-main">
+                <strong class="basket-item-title">${escapeHtml(getObjectDisplayName(item))}</strong>
+                <small class="basket-item-meta">ID: ${item.id} • ${escapeHtml(item.object_type?.name || '-')}</small>
             </div>
-            <button type="button" class="btn btn-danger btn-sm" data-id="${item.id}" aria-label="Ta bort ${escapeHtml(getObjectDisplayName(item))}">Ta bort</button>
+            <button type="button" class="basket-remove-btn" data-id="${item.id}" aria-label="Ta bort ${escapeHtml(getObjectDisplayName(item))}">✕</button>
         </div>
     `).join('');
 
-    list.querySelectorAll('button').forEach(button => {
+    list.querySelectorAll('.basket-remove-btn').forEach(button => {
         button.addEventListener('click', () => removeFromBasket(parseInt(button.dataset.id, 10)));
     });
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -134,7 +134,10 @@
                 <aside class="relation-basket-section" aria-label="Valda objekt">
                     <div class="basket-header">
                         <h4>Korg (<span id="relation-basket-count">0</span>/200)</h4>
-                        <button type="button" id="relation-clear-basket" class="btn btn-secondary btn-sm">Rensa</button>
+                        <div class="basket-actions">
+                            <button type="button" id="relation-clear-basket" class="btn btn-secondary btn-sm">Rensa</button>
+                            <button type="submit" form="relation-form" id="relation-connect-btn" class="btn btn-primary btn-sm">Koppla</button>
+                        </div>
                     </div>
                     <div id="relation-basket-list" class="relation-basket-list"></div>
 
@@ -164,11 +167,6 @@
                         </div>
                     </form>
                 </aside>
-            </div>
-
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" onclick="closeRelationModal()">Avbryt</button>
-                <button type="submit" form="relation-form" id="relation-connect-btn" class="btn btn-primary">Koppla</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Förbättra användarupplevelsen i relation-modalens korg genom att göra rader och knappar mer kompakta och visuellt läsbara.  
- Förhindra att modalens höjd växer när korgen fylls på genom att ge modalen en större initial arbetsyta och göra korglistan scrollbar.  
- Förenkla flödet genom att ta bort redundanta `Avbryt`/`modal-footer` och placera `Koppla` intill `Rensa` i korgsektionen.

### Description
- HTML: Flyttade `Koppla`-knappen in i korgens header (`templates/index.html`) och tog bort modal-footer och duplicerat `Avbryt`-element.  
- CSS: Uppdaterade design-tokenen `--bg-secondary` till `#f1f5f9`, gav `.relation-modal` en fast maxhöjd/initialhöjd och `overflow: hidden`, samt gjorde `.relation-basket-list` flex/scrollbar så att listan sköter overflow istället för att modalen expanderar (`static/css/style.css`).  
- CSS: Komprimerade korgrader/styles: mindre padding, kompakt typografi, ny `basket-remove-btn` (ikon), och stiländringar för `relation-add-btn` inklusive en `is-added` state för redan tillagda objekt.  
- JS: Bytte tabellens lägg-till-knappar till ikon-only (`+` / `✓`) med `disabled` och `is-added` när objekt redan finns i korgen, och uppdaterade `renderBasket()` för att alltid visa objektets ID samt använda en ikonbaserad ta-bort-knapp (`static/js/components/relation-manager.js`).

### Testing
- Körbarhetskontroll: `python -m py_compile app.py config.py new_database.py` kördes och lyckades.  
- Appstart (Postgres): `python app.py` misslyckades i miljön eftersom lokal PostgreSQL på `localhost:5432` saknades.  
- Appstart (SQLite): `DATABASE_URL=sqlite:////tmp/byggdemo.db python app.py` misslyckades eftersom modellen använder `JSONB` som inte renderas av SQLite i denna konfiguration.  
- Visuell QA: Ett automatiserat Playwright-skript för att ta screenshot kördes men kunde inte nå appen eftersom servern inte kunde startas i den här miljön.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba84beefc832083b1defcef4798c7)