### PR TITLE
Visa källobjekt i relationsmodal och fixa tabellhuvud vid scroll

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -198,6 +198,7 @@ body {
     overflow-y: auto;
     max-height: calc(100vh - 300px);
     position: relative;
+    isolation: isolate;
 }
 
 .data-table {
@@ -260,6 +261,13 @@ body {
 
 .data-table thead {
     background-color: var(--bg-tertiary);
+    position: relative;
+    z-index: 30;
+}
+
+.data-table tbody {
+    position: relative;
+    z-index: 1;
 }
 
 .data-table th {
@@ -273,7 +281,7 @@ body {
     position: sticky;
     top: 0;
     background-color: var(--bg-tertiary);
-    z-index: 10;
+    z-index: 30;
     transition: background-color 0.2s;
 }
 
@@ -592,6 +600,13 @@ body {
     flex-direction: column;
     height: 100%;
     min-height: 0;
+}
+
+.modal-context {
+    margin: var(--spacing-xs) 0 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
 .modal-subtitle {
@@ -1951,7 +1966,7 @@ body {
     position: sticky;
     top: calc(4px + 8px + 12px + 8px + 4px); /* Calculate header height */
     background-color: var(--bg-secondary);
-    z-index: 9;
+    z-index: 29;
     padding: var(--spacing-xs) var(--spacing-sm);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
     vertical-align: middle; /* Endast denna för vertikal centrering */

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,6 +99,7 @@
             <div class="modal-header">
                 <div>
                     <h3 id="relation-modal-title">Lägg till relationer</h3>
+                    <p id="relation-modal-source" class="modal-context"></p>
                     <p id="relation-modal-description" class="modal-subtitle">Sök, välj och koppla flera objekt i ett batch-anrop.</p>
                 </div>
                 <button class="close-btn" type="button" aria-label="Stäng relation-panel" onclick="closeRelationModal()">&times;</button>


### PR DESCRIPTION
### Motivation
- Användaren ska alltid se vilket objekt relationer läggs till för genom att visa objektets ID och namn i modal-headern. 
- När tabellinnehållet scrollas måste tabellhuvudet och kolumnsökraden ligga över innehållet så att rubriker alltid är synliga.

### Description
- Lagt till ett kontextelement i modal-headern: `#relation-modal-source` i `templates/index.html` för att visa källa (ID + namn). 
- Utökat modal-state i `static/js/components/relation-manager.js` med `sourceObject` och ny funktion `renderRelationModalSourceContext()` som renderar texten `Källobjekt: <ID> • <Namn>`. 
- Vid öppning av modalen hämtas källobjektet via `ObjectsAPI.getById()` med graceful fallback, och kontexten nollställs vid stängning i `closeRelationModal()`. 
- Justerat CSS i `static/css/style.css`: ny klass `.modal-context`, satt `isolation: isolate` på `.table-container`, och ökade z-index/positionering för `thead`, `th` och `.column-search-row th` samt lade `tbody` i egen stacking för att säkerställa att rubriker och sökrad ligger över tabellinnehållet.

### Testing
- Körbarhetskontroll: `python -m compileall -q .` kördes utan syntaxfel. 
- Testsvit: `pytest -q` kördes men inga tester fanns i repot ("no tests ran"). 
- Startförsök: `python app.py` misslyckades visuellt p.g.a. att PostgreSQL på `localhost:5432` inte var tillgänglig (connection refused), vilket blockerade visuell slutverifiering av modal och tabellbeteende.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c458d58b083208fc12c0e11f7545a)