### PR TITLE
Uppdatera trädvy med separata kolumner (Typ/Kravtext/Beskrivning), filkolumn och tätare indrag

### DIFF
--- a/static/css/TreeView.css
+++ b/static/css/TreeView.css
@@ -157,31 +157,49 @@
     font-weight: 400;
 }
 
-/* Reduced indentation per level (max 16px) */
+/* Reduced indentation per level (about 25% tighter for future density) */
 .tree-view-indent {
-    width: 16px;
+    width: 12px;
 }
 
 /* Column widths optimization */
 .tree-table th:nth-child(1),
 .tree-table td:nth-child(1) {
-    /* Name column - flex to take remaining space */
-    width: 50%;
-    min-width: 200px;
+    width: 34%;
+    min-width: 220px;
 }
 
 .tree-table th:nth-child(2),
 .tree-table td:nth-child(2) {
-    /* ID column - fixed width just enough for ID format */
-    width: 120px;
+    width: 14%;
     min-width: 100px;
 }
 
 .tree-table th:nth-child(3),
 .tree-table td:nth-child(3) {
-    /* Type column - remaining space */
-    width: 30%;
-    min-width: 100px;
+    width: 12%;
+    min-width: 110px;
+}
+
+.tree-table th:nth-child(4),
+.tree-table td:nth-child(4),
+.tree-table th:nth-child(5),
+.tree-table td:nth-child(5),
+.tree-table th:nth-child(6),
+.tree-table td:nth-child(6) {
+    width: 13%;
+    min-width: 140px;
+}
+
+.tree-file-link {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.tree-file-link:hover {
+    text-decoration: underline;
 }
 
 /* Sortable header styles */
@@ -235,12 +253,16 @@
 @media (max-width: 1400px) {
     .tree-table th:nth-child(1),
     .tree-table td:nth-child(1) {
-        width: 45%;
+        width: 30%;
     }
-    
-    .tree-table th:nth-child(2),
-    .tree-table td:nth-child(2) {
-        width: 110px;
+
+    .tree-table th:nth-child(4),
+    .tree-table td:nth-child(4),
+    .tree-table th:nth-child(5),
+    .tree-table td:nth-child(5),
+    .tree-table th:nth-child(6),
+    .tree-table td:nth-child(6) {
+        min-width: 120px;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Förbättra trädvyn så att relationsdata inte längre visas i "Typ/Relation"-kolumnen och istället visa fälten `kravtext` och `beskrivning` per objekt. 
- Visa bifogade filer i en egen kolumn och flytta relationsantalet till namn-kolumnen för bättre överblick (t.ex. `Kravställning (4)`).
- Minska indraget mellan nivåer (~25%) för att möjliggöra tätare hierarkier i framtiden utan att försämra läsbarheten.

### Description
- Backend: `GET /api/objects/tree` utökas så varje objekt returnerar `kravtext`, `beskrivning` och `files`, och en hjälpfunktion `get_data_value_case_insensitive` lades till för robust fälthämtning. (`routes/objects.py`).
- Frontend: `static/js/components/tree-view.js` uppdaterad för en 6-kolumnslayout (`Namn`, `ID`, `Typ`, `Kravtext`, `Beskrivning`, `Filer`), relationsdata tas bort från tabellen, gruppnoder visar antal i namnkolumnen, indrag minskas från 16px till 12px, filer renderas via `renderFiles` och texten escapas med `escapeHtml`, och klick på fil-länk stoppar rad-toggle. 
- CSS: `static/css/TreeView.css` justerad för nya kolumnbredder, minskat indrag (`.tree-view-indent`) och styling för fil-länkar. 
- Commit-separation: komponent/backend-ändringar och CSS-ändringar gjordes i separata commits som avsett. 
- Manual testinstruktioner (läggs i PR-beskrivningen som efterfrågat): starta appen, öppna Trädvy, expandera en Byggdel och verifiera att `Typ` inte visar relationstext, att kolumnerna `Kravtext` och `Beskrivning` visar data, att `Filer` listar filer (som länkar) när filer finns och är tom annars, att gruppnoder visar t.ex. `Kravställning (4)`, och att indraget är cirka 25% mindre men hierarkin fortfarande tydlig.

### Testing
- `node --test tests/js/object-list-display-name.test.mjs` kördes och alla 5 enhetstester passerade (ok 5/5). 
- Statisk kontroll: `node --check static/js/components/tree-view.js` och Python-syntaxkontroll `python -m py_compile routes/objects.py` kördes och lyckades. 
- Försök att starta appen med `python app.py` misslyckades i denna miljö eftersom PostgreSQL-anslutning saknas (`connection refused`), vilket blockerade end-to-end-verifiering och Playwright-screenshots. 
- Försök att seed:a lokalt med SQLite misslyckades på grund av PostgreSQL-specifika typer (`JSONB`) i schemat, varför inga före/efter-bilder kunde bifogas i denna körning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c66daabb88320942efbb75cec9e92)