### PR TITLE
Förbättra Dokument-flöde i detaljpanelen – skapa eller koppla dokumentobjekt

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ GET    /api/documents/{id}/download   # Ladda ner
 DELETE /api/documents/{id}            # Ta bort
 ```
 
+### Dokumentflöde i detaljpanelen (Dokument-tabben)
+- Två separata vägar visas i UI:t:
+  1. **Skapa och koppla nytt dokumentobjekt** (öppnar dialog med namn + filuppladdning)
+  2. **Koppla befintligt dokumentobjekt** (öppnar dialog med flervalslista av ritnings-/dokumentobjekt)
+- Nytt dokumentobjekt skapas som objekttypen **Ritningsobjekt/Dokumentobjekt** (första matchande typnamn), får namn via textfält och kopplas sedan med relationstypen `dokumenterar`.
+- Dokument-tabben visar även en lista över redan kopplade dokumentobjekt, med knappar för att öppna objektet eller koppla bort relationen.
 
 Relationer traverseras nu från båda håll i både API och frontend (objektpanel + trädvy), vilket ersätter behovet av direkta barn/förälder-kopplingar i objekten.
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1095,6 +1095,59 @@ body {
 }
 
 /* File Upload Styles */
+
+.document-link-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+}
+
+.document-path-card {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+    padding: var(--spacing-md);
+}
+
+.document-path-card h4 {
+    margin-bottom: var(--spacing-xs);
+}
+
+.document-path-card p {
+    margin-bottom: var(--spacing-md);
+    color: var(--text-secondary);
+}
+
+.document-object-modal {
+    z-index: 1003;
+}
+
+.document-object-modal-content {
+    max-width: 720px;
+}
+
+.existing-document-list {
+    max-height: 340px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-sm);
+    background-color: var(--bg-secondary);
+}
+
+.existing-document-option {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    border-radius: var(--radius-sm);
+}
+
+.existing-document-option:hover {
+    background-color: var(--bg-tertiary);
+}
+
 .file-upload {
     padding: var(--spacing-lg);
 }

--- a/static/js/components/object-detail-panel.js
+++ b/static/js/components/object-detail-panel.js
@@ -265,6 +265,7 @@ class ObjectDetailPanel {
         
         try {
             const fileUpload = new FileUploadComponent(containerId, this.objectData.id);
+            window.currentFileUpload = fileUpload;
             await fileUpload.render();
             container.dataset.loaded = 'true';
         } catch (error) {


### PR DESCRIPTION
### Motivation
- Göra dokumentkoppling i detaljpanelen mer flexibel genom att erbjuda både ett flöde för att skapa ett nytt dokument-/ritningsobjekt och ett flöde för att återanvända befintliga dokumentobjekt.
- Tydliggöra skillnaden mellan att ladda filer på ett objekt och att koppla separata dokumentobjekt till ett huvudobjekt.

### Description
- Implementerat två UI-flöden i `FileUploadComponent`: ett för "Skapa och koppla nytt dokumentobjekt" med namnfält och filuppladdning, och ett för "Koppla befintligt dokumentobjekt" med flervalslista och batch-koppling via relationstypen `dokumenterar`.
- Lagt till hantering av redan kopplade dokumentobjekt i dokumentfliken med knappar för att öppna objektet och att koppla bort relationen (`unlinkDocumentObject`).
- Säkerställt att `window.currentFileUpload` sätts från detaljpanelen genom en mindre ändring i `object-detail-panel.js` så globala åtgärder kan refresha rätt instans.
- Lagt till nya CSS-regler i `static/css/style.css` för kort, modal och listvy samt uppdaterad README-sektion som beskriver det nya dokumentflödet i detaljpanelen.

### Testing
- Körda statiska kontroller: `node --check static/js/components/file-upload.js` och `node --check static/js/components/object-detail-panel.js` lyckades.
- Kompilerade Python-kod och routes med `python -m compileall app.py routes static/js/components/file-upload.js` utan fel.
- `pytest -q` kördes men inga tester upptäcktes (`no tests ran`).
- Försök att starta hela appen och ta UI-screenshot blockerades eftersom lokal PostgreSQL inte var åtkomlig (fel: `connection refused`), så end-to-end-körning i den här miljön kunde inte verifieras.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c781596b483208038d0c5543aebf2)