### PR TITLE
Fixa kategori-visning och tom tree-view vid ny instans

### DIFF
--- a/defaults/plm-defaults.json
+++ b/defaults/plm-defaults.json
@@ -8626,5 +8626,356 @@
       "relation_type": "has_parent",
       "is_allowed": true
     }
+  ],
+  "classification_systems": [
+    {
+      "id": 1,
+      "name": "Byggdelar",
+      "description": "Internt klassifikationssystem",
+      "version": "1",
+      "is_active": true
+    },
+    {
+      "id": 2,
+      "name": "System",
+      "description": null,
+      "version": "1",
+      "is_active": true
+    },
+    {
+      "id": 3,
+      "name": "Spaces",
+      "description": null,
+      "version": "1",
+      "is_active": true
+    },
+    {
+      "id": 4,
+      "name": "Internt",
+      "description": "Internt klassifikationssystem",
+      "version": null,
+      "is_active": true
+    }
+  ],
+  "category_nodes": [
+    {
+      "id": 1,
+      "system_id": 1,
+      "parent_id": null,
+      "code": "S",
+      "name": "Stomme",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 14,
+      "system_id": 1,
+      "parent_id": null,
+      "code": "ISK",
+      "name": "Invändig stomkomplettering",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 15,
+      "system_id": 1,
+      "parent_id": null,
+      "code": "ESC",
+      "name": "Utvändig stomkomplettering",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 16,
+      "system_id": 1,
+      "parent_id": null,
+      "code": "INR",
+      "name": "Inredning",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 17,
+      "system_id": 3,
+      "parent_id": null,
+      "code": "ALL",
+      "name": "Allmänna utrymmen",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 18,
+      "system_id": 3,
+      "parent_id": null,
+      "code": "BOS",
+      "name": "Bostad",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 19,
+      "system_id": 3,
+      "parent_id": null,
+      "code": "TEK",
+      "name": "Teknikutrymmen",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 20,
+      "system_id": 3,
+      "parent_id": null,
+      "code": "GAR",
+      "name": "Kvartersmark",
+      "level": 1,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 2,
+      "system_id": 1,
+      "parent_id": 1,
+      "code": "C",
+      "name": "Pelare",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 5,
+      "system_id": 1,
+      "parent_id": 1,
+      "code": "SEW",
+      "name": "Bärande yttervägg",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 6,
+      "system_id": 1,
+      "parent_id": 1,
+      "code": "SIW",
+      "name": "Bärande Innervägg",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 12,
+      "system_id": 1,
+      "parent_id": 1,
+      "code": "MBJ",
+      "name": "Mellanbjälklag",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 39,
+      "system_id": 1,
+      "parent_id": 14,
+      "code": "INV",
+      "name": "Innerväggar",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 46,
+      "system_id": 1,
+      "parent_id": 14,
+      "code": "EBY",
+      "name": "Schaktväggar",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 47,
+      "system_id": 1,
+      "parent_id": 14,
+      "code": "EDT",
+      "name": "Mellanväggar",
+      "level": 2,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 3,
+      "system_id": 1,
+      "parent_id": 2,
+      "code": "CON",
+      "name": "Betongpelare",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 4,
+      "system_id": 1,
+      "parent_id": 2,
+      "code": "STE",
+      "name": "Stålpelare",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 7,
+      "system_id": 1,
+      "parent_id": 6,
+      "code": "SCC",
+      "name": "Platsgjuten betong",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 8,
+      "system_id": 1,
+      "parent_id": 6,
+      "code": "SKL",
+      "name": "Skalvägg",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 9,
+      "system_id": 1,
+      "parent_id": 6,
+      "code": "MCW",
+      "name": "Massiv betongvägg",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 10,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "VSK",
+      "name": "Bärande yttervägg Puts",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 11,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "EDV",
+      "name": "Bärande yttervägg Träpanel",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 13,
+      "system_id": 1,
+      "parent_id": 12,
+      "code": "HDE",
+      "name": "Håldäck",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 40,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "TES",
+      "name": "Bärande yttervägg Tegel",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 41,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "GRE",
+      "name": "Bärande yttervägg Klinker",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 42,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "KTD",
+      "name": "Bärande yttervägg Källarvägg",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 43,
+      "system_id": 1,
+      "parent_id": 5,
+      "code": "GTI",
+      "name": "Bärande yttervägg Skivmaterial",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 44,
+      "system_id": 1,
+      "parent_id": 12,
+      "code": "ETD",
+      "name": "Plattbärlag & Pågjutning",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    },
+    {
+      "id": 45,
+      "system_id": 1,
+      "parent_id": 12,
+      "code": "EBR",
+      "name": "Massivt bjälklag",
+      "level": 3,
+      "description": null,
+      "sort_order": 0,
+      "is_active": true
+    }
   ]
 }

--- a/new_database.py
+++ b/new_database.py
@@ -1,7 +1,9 @@
 from datetime import date, datetime
 
 from models import db, ObjectType, ObjectField, Object, ObjectData, ObjectRelation
+from models import ClassificationSystem, CategoryNode, ObjectCategoryAssignment
 from utils.default_seed_loader import load_default_seed_payload
+from sqlalchemy import text
 import logging
 
 logger = logging.getLogger(__name__)
@@ -75,6 +77,8 @@ def seed_data(app):
         object_type_specs = payload.get('object_types') if isinstance(payload, dict) else None
         object_specs = payload.get('objects') if isinstance(payload, dict) else None
         relation_specs = payload.get('object_relations') if isinstance(payload, dict) else None
+        classification_system_specs = payload.get('classification_systems') if isinstance(payload, dict) else None
+        category_node_specs = payload.get('category_nodes') if isinstance(payload, dict) else None
         if not isinstance(object_type_specs, list) or not object_type_specs:
             logger.warning("No object type defaults found in defaults/plm-defaults.json; skipping seed")
             return
@@ -89,6 +93,70 @@ def seed_data(app):
             object_types_by_name = {}
             fields_by_type_and_name = {}
             seeded_objects = {}
+
+            # Seed classification systems with preserved IDs so category_node field
+            # references (stored as numeric IDs in object data) remain valid.
+            if isinstance(classification_system_specs, list):
+                engine = db.session.get_bind()
+                for sys_spec in classification_system_specs:
+                    sys_id = sys_spec.get('id')
+                    if not sys_id:
+                        continue
+                    db.session.execute(text("""
+                        INSERT INTO classification_systems
+                            (id, name, description, version, is_active, created_at, updated_at)
+                        VALUES
+                            (:id, :name, :description, :version, :is_active,
+                             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    """), {
+                        'id': sys_id,
+                        'name': sys_spec.get('name'),
+                        'description': sys_spec.get('description'),
+                        'version': sys_spec.get('version'),
+                        'is_active': bool(sys_spec.get('is_active', True)),
+                    })
+                db.session.flush()
+                if engine.dialect.name == 'postgresql':
+                    db.session.execute(text(
+                        "SELECT setval('classification_systems_id_seq',"
+                        " (SELECT MAX(id) FROM classification_systems))"
+                    ))
+                logger.info("Seeded %d classification systems", len(classification_system_specs))
+
+            # Seed category nodes with preserved IDs (ordered by level to satisfy FK).
+            if isinstance(category_node_specs, list):
+                engine = db.session.get_bind()
+                nodes_ordered = sorted(category_node_specs, key=lambda n: (n.get('level', 1), n.get('id', 0)))
+                for node_spec in nodes_ordered:
+                    node_id = node_spec.get('id')
+                    if not node_id:
+                        continue
+                    db.session.execute(text("""
+                        INSERT INTO category_nodes
+                            (id, system_id, parent_id, code, name, level,
+                             description, sort_order, is_active, created_at, updated_at)
+                        VALUES
+                            (:id, :system_id, :parent_id, :code, :name, :level,
+                             :description, :sort_order, :is_active,
+                             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    """), {
+                        'id': node_id,
+                        'system_id': node_spec.get('system_id'),
+                        'parent_id': node_spec.get('parent_id'),
+                        'code': node_spec.get('code'),
+                        'name': node_spec.get('name'),
+                        'level': node_spec.get('level', 1),
+                        'description': node_spec.get('description'),
+                        'sort_order': node_spec.get('sort_order', 0),
+                        'is_active': bool(node_spec.get('is_active', True)),
+                    })
+                db.session.flush()
+                if engine.dialect.name == 'postgresql':
+                    db.session.execute(text(
+                        "SELECT setval('category_nodes_id_seq',"
+                        " (SELECT MAX(id) FROM category_nodes))"
+                    ))
+                logger.info("Seeded %d category nodes", len(category_node_specs))
 
             for object_type_payload in object_type_specs:
                 name = str(object_type_payload.get('name') or '').strip()
@@ -125,6 +193,9 @@ def seed_data(app):
                     fields_by_type_and_name[name][field_name] = object_field
                     created_fields += 1
 
+            # Track pending category assignments: (object_record, node_id)
+            pending_category_assignments = []
+
             if isinstance(object_specs, list):
                 for object_payload in object_specs:
                     object_type_name = str(object_payload.get('object_type') or '').strip()
@@ -151,10 +222,24 @@ def seed_data(app):
                             if field_record is None:
                                 continue
                             _assign_object_data(object_record, field_record, value)
+                            if field_record.field_type == 'category_node' and value is not None:
+                                raw_val = str(value).strip()
+                                if raw_val.isdigit():
+                                    pending_category_assignments.append((object_record, int(raw_val)))
 
                     seed_key = str(object_payload.get('seed_key') or '').strip()
                     if seed_key:
                         seeded_objects[seed_key] = object_record
+
+            # Create object_category_assignments so the tree-view can find objects
+            for obj_rec, node_id in pending_category_assignments:
+                db.session.add(ObjectCategoryAssignment(
+                    object_id=obj_rec.id,
+                    category_node_id=node_id,
+                    is_primary=True,
+                ))
+            if pending_category_assignments:
+                logger.info("Created %d category assignments", len(pending_category_assignments))
 
             if isinstance(relation_specs, list):
                 for relation_payload in relation_specs:

--- a/scripts/export_defaults_from_db.py
+++ b/scripts/export_defaults_from_db.py
@@ -246,6 +246,48 @@ def export_defaults(db_path, output_path):
             'created_at': relation_row['created_at'],
         })
 
+    system_rows = cur.execute(
+        """
+        SELECT id, name, description, version, is_active
+        FROM classification_systems
+        ORDER BY id ASC
+        """
+    ).fetchall()
+
+    classification_systems = [
+        {
+            'id': row['id'],
+            'name': row['name'],
+            'description': row['description'],
+            'version': row['version'],
+            'is_active': bool(row['is_active']),
+        }
+        for row in system_rows
+    ]
+
+    node_rows = cur.execute(
+        """
+        SELECT id, system_id, parent_id, code, name, level, description, sort_order, is_active
+        FROM category_nodes
+        ORDER BY level ASC, id ASC
+        """
+    ).fetchall()
+
+    category_nodes = [
+        {
+            'id': row['id'],
+            'system_id': row['system_id'],
+            'parent_id': row['parent_id'],
+            'code': row['code'],
+            'name': row['name'],
+            'level': row['level'],
+            'description': row['description'],
+            'sort_order': row['sort_order'],
+            'is_active': bool(row['is_active']),
+        }
+        for row in node_rows
+    ]
+
     payload = {
         'version': 1,
         'object_types': object_types,
@@ -253,6 +295,8 @@ def export_defaults(db_path, output_path):
         'object_relations': object_relations,
         'relation_types': relation_types,
         'relation_type_rules': relation_type_rules,
+        'classification_systems': classification_systems,
+        'category_nodes': category_nodes,
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Sammanfattning

- Exporterar `classification_systems` och `category_nodes` (med bevarade ID:n) i `export_defaults_from_db.py`
- `seed_data()` seedar nu klassificeringssystem och kategorinoder med explcita ID:n, samt skapar `object_category_assignments` för varje objekt med ett `category_node`-fält
- Återställer PostgreSQL-sekvenser efter inserts med explicita ID:n
- Uppdaterad `plm-defaults.json` med nuvarande DB-state inkl. klassificeringsdata