### PR TITLE
Fix relation type enforcement: default to 'auto' instead of 'referenc…

### DIFF
--- a/routes/object_relations.py
+++ b/routes/object_relations.py
@@ -95,7 +95,7 @@ def create_relation(id):
         if not target_object:
             return jsonify({'error': 'Invalid target_object_id'}), 400
 
-        relation_type = (data.get('relation_type') or DEFAULT_RELATION_TYPE).strip().lower() or DEFAULT_RELATION_TYPE
+        relation_type = (data.get('relation_type') or 'auto').strip().lower() or 'auto'
         relation_type, source_object, target_object, _ = normalize_relation_direction(
             relation_type=relation_type,
             source_object=source_object,

--- a/routes/relation_entities.py
+++ b/routes/relation_entities.py
@@ -78,7 +78,7 @@ def create_relation():
 
     source_object_id = data.get('source_object_id') or data.get('objectA_id')
     target_object_id = data.get('target_object_id') or data.get('objectB_id')
-    relation_type = (data.get('relation_type') or DEFAULT_RELATION_TYPE).strip().lower() or DEFAULT_RELATION_TYPE
+    relation_type = (data.get('relation_type') or 'auto').strip().lower() or 'auto'
 
     if not source_object_id or not target_object_id:
         return jsonify({'error': 'source_object_id/objectA_id and target_object_id/objectB_id are required'}), 400

--- a/static/js/components/file-upload.js
+++ b/static/js/components/file-upload.js
@@ -877,7 +877,8 @@ class FileUploadComponent {
 
                 // 3) Koppla filobjektet till aktivt objekt
                 await ObjectsAPI.addRelation(this.objectId, {
-                    target_object_id: createdObject.id
+                    target_object_id: createdObject.id,
+                    relation_type: 'auto'
                 });
                 createdCount += 1;
             }
@@ -926,7 +927,8 @@ class FileUploadComponent {
 
         try {
             await Promise.all(selectedIds.map(targetId => ObjectsAPI.addRelation(this.objectId, {
-                target_object_id: targetId
+                target_object_id: targetId,
+                relation_type: 'auto'
             })));
 
             showToast('Valda filobjekt kopplades', 'success');


### PR DESCRIPTION
…es_object'

When creating relations without specifying a relation_type, the system was defaulting to 'references_object'. This caused failures when Admin had configured a different relation type for the source/target pair (e.g. 'has_document' for fileObject <-> connection).

The fix passes 'auto' as the default so the backend resolves the correct relation type from the configured Admin rules via enforce_pair_relation_type.

- file-upload.js: explicitly send relation_type: 'auto' in addRelation calls
- object_relations.py: default missing relation_type to 'auto'
- relation_entities.py: default missing relation_type to 'auto'

https://claude.ai/code/session_01LfL8NLAP4F1TWL5pFLQd3n