### PR TITLE
Fix: richtext visas som råformat i table view

### DIFF
--- a/static/js/components/object-list.js
+++ b/static/js/components/object-list.js
@@ -1039,7 +1039,13 @@ class ObjectListComponent {
 
     normalizeSortableText(value) {
         const asString = String(value ?? '');
-        const stripped = /<[^>]+>/.test(asString) ? stripHtmlTags(asString) : asString;
+        let html = asString;
+        if (!/<\s*[a-z][^>]*>/i.test(html) && /&lt;\s*[a-z][^&]*&gt;/i.test(html)) {
+            const decoder = document.createElement('textarea');
+            decoder.innerHTML = html;
+            html = decoder.value || html;
+        }
+        const stripped = /<[^>]+>/.test(html) ? stripHtmlTags(html) : html;
         return stripped.replace(/\s+/g, ' ').trim();
     }
 
@@ -1326,6 +1332,16 @@ class ObjectListComponent {
 
         if (resolvedValue && typeof resolvedValue === 'object') {
             return this.highlightText(JSON.stringify(resolvedValue), fieldName);
+        }
+
+        if (column?.field_type === 'richtext' && typeof resolvedValue === 'string') {
+            let html = resolvedValue;
+            if (!/<\s*[a-z][^>]*>/i.test(html) && /&lt;\s*[a-z][^&]*&gt;/i.test(html)) {
+                const decoder = document.createElement('textarea');
+                decoder.innerHTML = html;
+                html = decoder.value || '';
+            }
+            return this.highlightText(stripHtmlTags(html), fieldName);
         }
 
         if (typeof resolvedValue === 'string' && /<[^>]+>/.test(resolvedValue)) {


### PR DESCRIPTION
## Sammanfattning

Richtext-fält visade rå HTML-markup i table view istället för ren plaintext.

## Förklaring

`formatColumnValue` i `object-list.js` hanterade `textarea` explicit men förlitade sig för `richtext` enbart på en generisk HTML-tag-regex (`/<[^>]+>/`). Den regexen misslyckas om värdet är entity-kodat (`&lt;p&gt;Hello&lt;/p&gt;` istället för `<p>Hello</p>`), vilket gör att rå markup visas i tabellcellen.

## Ändringar (`object-list.js`)

- Ny explicit `field_type === 'richtext'`-gren i `formatColumnValue` som avkodar entity-HTML (samma mönster som `object-detail-panel.js` använder) innan `stripHtmlTags` anropas
- Samma avkodning i `normalizeSortableText` för korrekt sortering på richtext-kolumner

## Testplan

- [ ] Richtext-fält i table view ska visa ren plaintext utan HTML-taggar
- [ ] Sortering på richtext-kolumn ska fungera korrekt

https://claude.ai/code/session_01LfL8NLAP4F1TWL5pFLQd3n