### PR TITLE
Handle DB flush exceptions in batch relation creation

### DIFF
--- a/routes/relation_entities.py
+++ b/routes/relation_entities.py
@@ -251,7 +251,12 @@ def create_relations_batch():
             description=metadata.get('description') if isinstance(metadata, dict) else None
         )
         db.session.add(relation)
-        db.session.flush()
+        try:
+            db.session.flush()
+        except Exception as exc:
+            db.session.rollback()
+            errors.append({'index': index, 'targetId': target_id, 'error': str(exc)})
+            continue
         created.append(relation.to_dict(include_objects=True))
         if target_id_full:
             batch_linked_id_fulls.add(target_id_full)


### PR DESCRIPTION
Wrap db.session.flush() in a try/except so that a FK violation or other DB error on a single row appends to errors[] and rolls back only that row, instead of propagating as an unhandled 500 for the whole request.

https://claude.ai/code/session_013AuYTvtRAne3T7HJJzkRmZ